### PR TITLE
Disable external data checker

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "disable-external-data-checker": true
+}


### PR DESCRIPTION
It produces only PRs with updates which fail to build. Updating any dependencies required manual work every single time so far. I don't see this changing any time soon.