### PR TITLE
Update to Euterpe GTK 0.7.2

### DIFF
--- a/com.doycho.euterpe.gtk.json
+++ b/com.doycho.euterpe.gtk.json
@@ -42,7 +42,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/ironsmile/euterpe-gtk.git",
-                    "commit": "1ba3d3d3932410c9ace6ab363708eb3f37abc5db"
+                    "tag": "v0.7.2",
+                    "commit": "6962a65c4331eabf4d4d7a125c5668409c3b220a"
                 }
             ]
         }

--- a/com.doycho.euterpe.gtk.json
+++ b/com.doycho.euterpe.gtk.json
@@ -42,8 +42,8 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/ironsmile/euterpe-gtk.git",
-                    "tag": "v0.6.3",
-                    "commit": "481506c662b9ce3d3cc4df28c6d8bd961f4eab71"
+                    "tag": "v0.7.1",
+                    "commit": "fad9d5e97b3492a158a469c43e691dde46c7fa25"
                 }
             ]
         }

--- a/com.doycho.euterpe.gtk.json
+++ b/com.doycho.euterpe.gtk.json
@@ -42,8 +42,7 @@
                 {
                     "type" : "git",
                     "url" : "https://github.com/ironsmile/euterpe-gtk.git",
-                    "tag": "v0.7.1",
-                    "commit": "fad9d5e97b3492a158a469c43e691dde46c7fa25"
+                    "commit": "1ba3d3d3932410c9ace6ab363708eb3f37abc5db"
                 }
             ]
         }

--- a/libhandy.json
+++ b/libhandy.json
@@ -14,7 +14,7 @@
         {
             "type" : "git",
             "url" : "https://gitlab.gnome.org/GNOME/libhandy",
-            "tag" : "1.2.1"
+            "tag" : "1.8.3"
         }
     ]
 }


### PR DESCRIPTION
This ended up being an update to 0.7.2. A few AppStream metadata changes were needed before the Flathub builder validations could be passed.