### PR TITLE
Update com.doycho.euterpe.gtk runtime to 46

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.doycho.euterpe.gtk.json
+++ b/com.doycho.euterpe.gtk.json
@@ -29,6 +29,7 @@
         "*.a"
     ],
     "modules" : [
+        "shared-modules/libsoup/libsoup-2.4.json",
         "libhandy.json",
         "python-setuptools-rust.json",
         "cryptography-python-deps.json",

--- a/com.doycho.euterpe.gtk.json
+++ b/com.doycho.euterpe.gtk.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "com.doycho.euterpe.gtk",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "43",
+    "runtime-version" : "46",
     "sdk" : "org.gnome.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.rust-stable"


### PR DESCRIPTION
- Update com.doycho.euterpe.gtk runtime to 46 since runtime version 44 has reached end-of-life.
- Add required/missing libsoup module from Flathub shared modules.